### PR TITLE
Fix error caused by thaumic tinker fake player.

### DIFF
--- a/src/main/java/lotr/common/enchant/LOTREnchantmentHelper.java
+++ b/src/main/java/lotr/common/enchant/LOTREnchantmentHelper.java
@@ -673,7 +673,9 @@ public class LOTREnchantmentHelper {
 				}
 				if (progressChanged && !enchantsChanged) {
 					IMessage pkt = new LOTRPacketCancelItemHighlight();
-					LOTRPacketHandler.networkWrapper.sendTo(pkt, (EntityPlayerMP) entityplayer);
+					if (entityplayer instanceof EntityPlayerMP) {
+                        LOTRPacketHandler.networkWrapper.sendTo(pkt, (EntityPlayerMP) entityplayer);
+                    }
 				}
 			}
 		}


### PR DESCRIPTION
Fakeplayer may not be EntityPlayerMP,causes CCE

what I encountered:
---- Minecraft Crash Report ----
// I let you down. Sorry :(

Time: 25-2-28 上午9:18
Description: Ticking block entity

java.lang.ClassCastException: thaumic.tinkerer.common.block.tile.tablet.TabletFakePlayer cannot be cast to net.minecraft.entity.player.EntityPlayerMP
	at lotr.common.enchant.LOTREnchantmentHelper.onKillEntity(LOTREnchantmentHelper.java:934)
	at lotr.common.LOTREventHandler.onLivingDeath(LOTREventHandler.java:2780)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_101_LOTREventHandler_onLivingDeath_LivingDeathEvent.invoke(.dynamic)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraftforge.common.ForgeHooks.onLivingDeath(ForgeHooks.java:303)
	at net.minecraft.entity.EntityLivingBase.func_70645_a(EntityLivingBase.java:891)
	at net.minecraft.entity.monster.EntitySkeleton.func_70645_a(SourceFile:152)
	at net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:855)
	at net.minecraft.entity.monster.EntityMob.func_70097_a(SourceFile:54)
	at net.minecraft.entity.player.EntityPlayer.func_71059_n(EntityPlayer.java:1232)
	at thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet.swingHit(TileAnimationTablet.java:165)
	at thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet.func_145845_h(TileAnimationTablet.java:114)
	at net.minecraft.world.World.func_72939_s(World.java:1939)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at lotr.common.enchant.LOTREnchantmentHelper.onKillEntity(LOTREnchantmentHelper.java:934)
	at lotr.common.LOTREventHandler.onLivingDeath(LOTREventHandler.java:2780)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_101_LOTREventHandler_onLivingDeath_LivingDeathEvent.invoke(.dynamic)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraftforge.common.ForgeHooks.onLivingDeath(ForgeHooks.java:303)
	at net.minecraft.entity.EntityLivingBase.func_70645_a(EntityLivingBase.java:891)
	at net.minecraft.entity.monster.EntitySkeleton.func_70645_a(SourceFile:152)
	at net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:855)
	at net.minecraft.entity.monster.EntityMob.func_70097_a(SourceFile:54)
	at net.minecraft.entity.player.EntityPlayer.func_71059_n(EntityPlayer.java:1232)
	at thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet.swingHit(TileAnimationTablet.java:165)
	at thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet.func_145845_h(TileAnimationTablet.java:114)

-- Block entity being ticked --
Details:
	Name: ttinkerer:animationTablet // thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet
	Block type: ID #1134 (tile.animationTablet // thaumic.tinkerer.common.block.BlockAnimationTablet)
	Block data value: 4 / 0x4 / 0b0100
	Block location: World: (761,25,-38), Chunk: (at 9,1,10 in 47,-3; contains blocks 752,0,-48 to 767,255,-33), Region: (1,-1; contains chunks 32,-32 to 63,-1, blocks 512,0,-512 to 1023,255,-1)
	Actual block type: ID #1134 (tile.animationTablet // thaumic.tinkerer.common.block.BlockAnimationTablet)
	Actual block data value: 4 / 0x4 / 0b0100
Stacktrace:
	at net.minecraft.world.World.func_72939_s(World.java:1939)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)

-- Affected level --
Details:
	Level name: 新的世界
	All players: 1 total; [EntityPlayerMP['Acdeasdff'/245, l='新的世界', x=760.57, y=24.00, z=-36.64]]
	Chunk stats: ServerChunkCache: 923 Drop: 0
	Level seed: 2328421033746400270
	Level generator: ID 04 - middleEarth, ver 0. Features enabled: true
	Level generator options: 
	Level spawn location: World: (-52,64,248), Chunk: (at 12,4,8 in -4,15; contains blocks -64,0,240 to -49,255,255), Region: (-1,0; contains chunks -32,0 to -1,31, blocks -512,0,0 to -1,255,511)
	Level time: 1768953 game time, 37473 day time
	Level dimension: -1
	Level storage version: 0x04ABD - Anvil
	Level weather: Rain time: 77140 (now: false), thunder time: 13281 (now: false)
	Level game mode: Game mode: survival (ID 0). Hardcore: false. Cheats: true
Stacktrace:
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)

-- System Details --
Details:
	Minecraft Version: 1.7.10
	Operating System: Windows 8.1 (amd64) version 6.3
	Java Version: 1.8.0_51, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 5506414680 bytes (5251 MB) / 8799649792 bytes (8392 MB) up to 8803844096 bytes (8396 MB)
	Mod Pack: Unknown / None
	LiteLoader Mods: none
	LaunchWrapper: 53 active transformer(s)
          - Transformer: cpw.mods.fml.common.asm.transformers.PatchingTransformer
          - Transformer: com.mumfrey.liteloader.transformers.event.EventProxyTransformer
          - Transformer: com.mumfrey.liteloader.launch.LiteLoaderTransformer
          - Transformer: com.mumfrey.liteloader.client.transformers.CrashReportTransformer
          - Transformer: org.spongepowered.asm.mixin.transformer.Proxy
          - Transformer: io.github.legacymoddingmc.unimixins.gtnhmixins.asm.LegacyGTNHMixinExtrasGenerator
          - Transformer: io.github.legacymoddingmc.unimixins.compat.asm.ASMRemapperTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.MarkerTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.SideTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.EventSubscriptionTransformer
          - Transformer: net.minecraftforge.classloading.FluidIdTransformer
          - Transformer: codechicken.lib.asm.ClassHeirachyManager
          - Transformer: codechicken.core.asm.TweakTransformer
          - Transformer: codechicken.core.asm.DelegatedTransformer
          - Transformer: codechicken.core.asm.DefaultImplementationTransformer
          - Transformer: codechicken.lib.asm.RedirectorTransformer
          - Transformer: codechicken.nei.asm.NEITransformer
          - Transformer: witchinggadgets.asm.WGCoreTransformer
          - Transformer: thaumic.tinkerer.preloader.AccessTransformer
          - Transformer: DummyCore.ASM.DCASMManager
          - Transformer: metweaks.core.ClassTransformer
          - Transformer: lain.mods.skinport.init.forge.asm.ASMTransformer
          - Transformer: io.github.legacymoddingmc.unimixins.compat.asm.EnhanceCrashReportsTransformer
          - Transformer: org.embeddedt.archaicfix.asm.ArchaicTransformer
          - Transformer: com.gtnewhorizon.gtnhlib.core.transformer.EventBusSubTransformer
          - Transformer: com.mitchej123.hodgepodge.asm.transformers.fml.SpeedupProgressBarTransformer
          - Transformer: com.mitchej123.hodgepodge.asm.transformers.mc.SpeedupLongIntHashMapTransformer
          - Transformer: com.mitchej123.hodgepodge.asm.transformers.mc.NBTTagCompoundHashMapTransformer
          - Transformer: com.mitchej123.hodgepodge.asm.transformers.fml.FMLIndexedMessageToMessageCodecTransformer
          - Transformer: com.mitchej123.hodgepodge.asm.transformers.optifine.GLErrorLoggingTransformer
          - Transformer: me.guichaguri.betterfps.transformers.MathTransformer
          - Transformer: me.guichaguri.betterfps.transformers.EventTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.DeobfuscationTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.AccessTransformer
          - Transformer: net.minecraftforge.transformers.ForgeAccessTransformer
          - Transformer: codechicken.core.asm.CodeChickenAccessTransformer
          - Transformer: thaumic.tinkerer.preloader.AccessTransformer
          - Transformer: makeo.gadomancy.coremod.GadomancyTransformer
          - Transformer: io.github.legacymoddingmc.unimixins.all.AllCore$CombinedAccessTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.ModAccessTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.ItemStackTransformer
          - Transformer: org.spongepowered.asm.mixin.transformer.Proxy
          - Transformer: pl.asie.foamfix.bugfixmod.coremod.BugfixModClassTransformer
          - Transformer: lotr.common.coremod.LOTRClassTransformer
          - Transformer: io.gitlab.dwarfyassassin.lotrucp.core.UCPClassTransformer
          - Transformer: net.glease.tc4tweak.asm.TC4Transformer
          - Transformer: cpw.mods.fml.common.asm.transformers.TerminalTransformer
          - Transformer: org.spongepowered.asm.mixin.transformer.Proxy
          - Transformer: com.gtnewhorizon.gtnhlib.core.transformer.TessellatorRedirectorTransformer
          - Transformer: com.mumfrey.liteloader.client.transformers.LiteLoaderEventInjectionTransformer
          - Transformer: com.mumfrey.liteloader.client.transformers.MinecraftOverlayTransformer
          - Transformer: com.mumfrey.liteloader.common.transformers.LiteLoaderPacketTransformer
          - Transformer: cpw.mods.fml.common.asm.transformers.ModAPITransformer
	JVM Flags: 6 total; -XX:+UseG1GC -XX:-UseAdaptiveSizePolicy -XX:-OmitStackTraceInFastThrow -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xmn1259m -Xmx8396m
	AABB Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	IntCache: cache: 1, tcache: 1, allocated: 12, tallocated: 94
	FML: MCP v9.05 FML v7.10.99.99 Minecraft Forge 10.13.4.1614 56 mods loaded, 56 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored
	UCHIJAAAA	mcp{9.05} [Minecraft Coder Pack] (minecraft.jar) 
	UCHIJAAAA	FML{7.10.99.99} [Forge Mod Loader] (forge-1.7.10-10.13.4.1614-1.7.10.jar) 
	UCHIJAAAA	Forge{10.13.4.1614} [Minecraft Forge] (forge-1.7.10-10.13.4.1614-1.7.10.jar) 
	UCHIJAAAA	CodeChickenCore{1.4.1} [CodeChicken Core] (minecraft.jar) 
	UCHIJAAAA	NotEnoughItems{2.7.28-GTNH} [NotEnoughItems] (2[NEI物品管理器非官方版] NotEnoughItems-2.7.28-GTNH.jar) 
	UCHIJAAAA	WitchingGadgetsCore{1.1.10} [Witching Gadgets Core] (minecraft.jar) 
	UCHIJAAAA	ThaumicTinkerer-preloader{0.1} [Thaumic Tinkerer Core] (minecraft.jar) 
	UCHIJAAAA	GTNHLib Core{0.6.2} [GTNHLib Core] (minecraft.jar) 
	UCHIJAAAA	FoamFixCore{1.0.4} [FoamFixCore] (minecraft.jar) 
	UCHIJAAAA	Baubles{2.1.4} [Baubles] (BaublesExpanded-2.1.4.jar) 
	UCHIJAAAA	Thaumcraft{4.2.3.5} [Thaumcraft] (Thaumcraft-1.7.10-4.2.3.5.jar) 
	UCHIJAAAA	NodalMechanics{1.7.10R1.0} [NodalMechanics] (5[节点力学] NodalMechanics-1.7-1.0-7.jar) 
	UCHIJAAAA	UnicodeFontFixer{1.1.12-mc1.7.10} [UnicodeFontFixer] ([Unicode字体修复] UnicodeFontFixer-1.1.12-mc1.7.10.jar) 
	UCHIJAAAA	lotr{Update v36.15 for Minecraft 1.7.10} [The Lord of the Rings Mod] ([魔戒：传承] LOTRMod v36.15.jar) 
	UCHIJAAAA	mett{0.7.3.1} [Middle-Earth Thaumaturgy] ([中土神秘学] middleearththaumaturgy-0.7.3.1_a for v36.x.jar) 
	UCHIJAAAA	entityculling{@VER@} [EntityCulling] ([实体渲染机制优化] entityculling-1.6.4-mc1.7.10.jar) 
	UCHIJAAAA	TravellersGear{1.16.6} [Traveller's Gear] ([旅者之器] TravellersGear-1.7.10-1.16.6.jar) 
	UCHIJAAAA	WitchingGadgets{1.1.10} [Witching Gadgets] ([巫师宝具] WitchingGadgets-1.7.10-1.1.10.jar) 
	UCHIJAAAA	journeymap{5.2.8} [JourneyMap] ([旅行地图] journeymap-1.7.10-5.2.8-unlimited.jar) 
	UCHIJAAAA	exnihilo{1.38-53} [Ex Nihilo] ([无中生有] Ex-Nihilo-1.38-53.jar) 
	UCHIJAAAA	exastris{MC1.7.10-1.16-36} [Ex Astris] ([星辉生万物] Ex-Astris-MC1.7.10-1.16-36.jar) 
	UCHIJAAAA	TaintedMagic{8.1.1} [Tainted Magic] ([污秽魔法] Tainted-Magic-1.7.10-8.1.1.jar) 
	UCHIJAAAA	foamfix{@VERSION@} [FoamFix] ([泡沫修复] FoamFix-1.7.10-universal-1.0.4.jar) 
	UCHIJAAAA	DummyCore{1.13} [DummyCore] (DummyCore1.13.jar) 
	UCHIJAAAA	thaumicbases{1.3.1710.2} [Thaumic Bases] ([神秘基础学] ThaumicBases-1.3.1710.4.jar) 
	UCHIJAAAA	Waila{1.5.10} [Waila] ([高亮信息拓展] Waila-1.5.10_1.7.10.jar) 
	UCHIJAAAA	ThaumicTinkerer{unspecified} [Thaumic Tinkerer] ([神秘工匠] ThaumicTinkerer-2.5-1.7.10-164.jar) 
	UCHIJAAAA	thaumcraftneiplugin{@VERSION@} [Thaumcraft NEI Plugin] ([神秘时代NEI插件] thaumcraftneiplugin-1.7.10-1.7a.jar) 
	UCHIJAAAA	tcinventoryscan{1.0.11} [TC Inventory Scanning] ([神秘时代物品栏扫描] tcinventoryscan-mc1.7.10-1.0.11.jar) 
	UCHIJAAAA	ThaumicHorizons{1.7.1} [ThaumicHorizons] ([神秘视界] ThaumicHorizons-1.7.1.jar) 
	UCHIJAAAA	ForbiddenMagic{1.7.10-0.575} [Forbidden Magic] ([禁忌魔法] Forbidden Magic-1.7.10-0.575.jar) 
	UCHIJAAAA	Automagy{0.28.2} [Automagy] ([自动化魔法] Automagy-1.7.10-0.28.2.jar) 
	UCHIJAAAA	VeinMiner{0.36.0_1.7.10-28a7f13} [Vein Miner] ([连锁采矿／矿脉矿工] VeinMiner-1.7.10-0.36.0.496+28a7f13.jar) 
	UCHIJAAAA	VeinMinerModSupport{0.36.0_1.7.10-28a7f13} [Mod Support] ([连锁采矿／矿脉矿工] VeinMiner-1.7.10-0.36.0.496+28a7f13.jar) 
	UCHIJAAAA	neodymium{0.4.3-unofficial} [Neodymium Unofficial] ([钕：非官方版] neodymium-mc1.7.10-0.4.3-unofficial.jar) 
	UCHIJAAAA	gadomancy{1.0.7.3} [Gadomancy] ([魔像秘经] gadomancy-1.7.10-1.0.7.3.jar) 
	UCHIJAAAA	unimixins{0.1.19} [UniMixins] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	gtnhmixins{2.2.0} [UniMixins: GTNHMixins] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	archaicfix{0.7.4} [ArchaicFix] (archaicfix-0.7.4.jar) 
	UCHIJAAAA	gtnhlib{0.6.2} [GTNH Lib] (gtnhlib-0.6.2.jar) 
	UCHIJAAAA	hodgepodge{2.6.23} [Hodgepodge] (hodgepodge-2.6.23.jar) 
	UCHIJAAAA	neirecipehandlers{1.1.0-BETA} [NEI Recipe Handlers] (neiRecipeHandlers-1.1.0-BETA.jar) 
	UCHIJAAAA	skinport{1.7.10-v10d} [SkinPort] (SkinPort-1.7.10-v10d.jar) 
	UCHIJAAAA	thaumicinsurgence{0.0.2.6} [Thaumic Insurgence] (thaumicinsurgence-0.0.2.6.jar) 
	UCHIJAAAA	uuidoffline{1.0} [UUIDOffline] (uuidoffline-1.0.jar) 
	UCHIJAAAA	WailaHarvestability{1.1.6} [Waila Harvestability] (WailaHarvestability-mc1.7.10-1.1.6.jar) 
	UCHIJAAAA	unimixins-mixin{0.1.19} [UniMixins: Mixin (UniMix)] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	unimixins-compat{0.1.19} [UniMixins: Compatibility] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	mixingasm{0.3} [UniMixins: Mixingasm] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	spongemixins{2.0.1} [UniMixins: SpongeMixins] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	mixinbooterlegacy{1.2.1} [UniMixins: MixinBooterLegacy] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	gasstation{0.5.1} [UniMixins: GasStation] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	mixinextras{0.1.19} [UniMixins: MixinExtras] (4+unimixins-all-1.7.10-0.1.19.jar) 
	UCHIJAAAA	Baubles|Expanded{2.1.4} [Baubles Expanded] (BaublesExpanded-2.1.4.jar) 
	UCHIJAAAA	tc4tweak{1.5.29-beta.2} [TC4 Tweak] (Thaumcraft4Tweaks-1.5.29-beta.2.jar) 
	UCHIJAAAA	metweaks{1.5.1} [MiddleEarth Tweaks] (MiddleEarth-Tweaks-1.5.1.jar) 
	GL info: ~~ERROR~~ RuntimeException: No OpenGL context found in the current thread.
	CPU Threads: 12
	TC4Tweak signing signature: 473C3A397676978FF4877ABA2D57860DDA20E2FC, Built by: glease
	NEI Recipe Handlers modules: : NEI LOTR (1.0.0-BETA); NEI Recipe Handlers (1.1.0-BETA); 
	Mixins in Stacktrace: 
		net.minecraftforge.common.ForgeHooks:
			mixins.hodgepodge.early.json:minecraft.MixinForgeHooks from mod hodgepodge
			mixins.hodgepodge.early.json:forge.MixinForgeHooks_ModernPickBlock from mod hodgepodge
		net.minecraft.world.World:
			mixins.archaicfix.early.json:client.lighting.MixinWorld from mod archaicfix
			mixins.archaicfix.early.json:common.lighting.MixinWorld_Lighting from mod archaicfix
			mixins.hodgepodge.early.json:minecraft.MixinWorld_FixXray from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinWorldLightValue from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinWorldGetBlock from mod hodgepodge
			mixins.archaicfix.early.json:common.core.MixinWorld from mod archaicfix
			mixins.hodgepodge.early.json:minecraft.MixinWorld_FixAllocations from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinWorldUpdateEntities from mod hodgepodge
		net.minecraft.entity.EntityLivingBase:
			mixins.hodgepodge.early.json:minecraft.MixinEntityLivingBase_FixPotionException from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinEntityLivingBase_FixHasteArmSwing from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinEntityLivingBase_HidePotionParticles from mod hodgepodge
			mixins.archaicfix.early.json:common.core.MixinEntityLivingBase_EarlyXpDrop from mod archaicfix
		net.minecraft.entity.player.EntityPlayer:
			mixins.hodgepodge.early.json:minecraft.MixinEntityPlayer from mod hodgepodge
		net.minecraft.server.integrated.IntegratedServer:
			mixins.archaicfix.early.json:client.core.MixinIntegratedServer from mod archaicfix
		cpw.mods.fml.common.eventhandler.EventBus:
			mixins.gtnhlib.early.json:fml.EventBusAccessor from mod gtnhlib
		net.minecraft.world.WorldServer:
			mixins.archaicfix.early.json:common.core.MixinWorldServer from mod archaicfix
			mixins.hodgepodge.early.json:minecraft.MixinWorldServer_LimitUpdateRecursion from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinWorldServer_FixAllocations from mod hodgepodge
			mixins.hodgepodge.early.json:minecraft.MixinWorldServerUpdateEntities from mod hodgepodge
	Profiler Position: N/A (disabled)
	Vec3 Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	Player Count: 1 / 8; [EntityPlayerMP['Acdeasdff'/245, l='新的世界', x=760.57, y=24.00, z=-36.64]]
	Type: Integrated Server (map_client.txt)
	Is Modded: Definitely; Client brand changed to 'fml,forge'